### PR TITLE
Re-do comparisons for 3.11.3

### DIFF
--- a/.github/workflows/comparison.yaml
+++ b/.github/workflows/comparison.yaml
@@ -37,13 +37,13 @@ jobs:
     steps:
       # https://github.com/NixOS/nixpkgs/tree/2f2c8b33a3dc4bf9a3db1648d734fa8c64f9166b
       - name: Checkout Nixpkgs
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: NixOS/nixpkgs
           ref: 2f2c8b33a3dc4bf9a3db1648d734fa8c64f9166b
 
       - name: Install Determinate Nix
-        uses: DeterminateSystems/determinate-nix-action@v3.9.1
+        uses: DeterminateSystems/determinate-nix-action@v3.11.3
 
       - name: Set up FlakeHub Cache
         uses: DeterminateSystems/flakehub-cache-action@main


### PR DESCRIPTION
Past result: https://github.com/DeterminateSystems/lazy-trees-comparisons/actions/runs/17297806714

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow to use the latest versions of build tools and infrastructure dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->